### PR TITLE
DOC: depend on pyarrow

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,6 +6,7 @@ ipykernel
 jupyter-sphinx
 pedalboard >=0.4.0
 praat-parselmouth
+pyarrow  # to avoid pandas deprecation warning
 pydub  # required by audiomentations
 sox
 sphinx==5.3.0


### PR DESCRIPTION
This adds `pyarrow` as a dependency to avoid a failing test due to a `pandas` deprecation warning.
It's still not completely settled if `pandas` 3.0 will really depend on `pyarrow` or not (https://github.com/pandas-dev/pandas/issues/54466#issuecomment-1908775392), but until then it seems to be the easiest solution to just install it.