### PR TITLE
DOC: simplify ffmpeg installation instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -13,17 +13,11 @@ To install :mod:`auglib` run:
 :class:`auglib.transform.AMRNB`,
 requires ``ffmpeg``
 with support for the AMR-NB format.
-Under Ubuntu 22.04 this can be achieved by:
+Under Ubuntu this can be achieved by:
 
 .. code-block:: bash
 
-    $ sudo apt install ffmpeg libavcodec-extra58
-
-On older or newer distributions,
-the package might be named
-``libavcodec-extra57``,
-``libavcodec-extra59``,
-and so on.
+    $ sudo apt install ffmpeg libavcodec-extra
 
 :class:`auglib.transform.CompressDynamicRange`
 requires ``sox``,


### PR DESCRIPTION
Simplify the installation instructions for `libavcodec-extra` as it is not neccessary to know its available version.

![image](https://github.com/audeering/auglib/assets/173624/c6d9bb96-3de9-4bbf-ad56-50b9b7e07d09)
