### PR TITLE
DOC: fix sphinx build dir in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -67,8 +67,8 @@ and call it directly::
 
 It can be restricted to specific folders::
 
-    ruff check audfoo/ tests/
-    codespell audfoo/ tests/
+    ruff check auglib/ tests/
+    codespell auglib/ tests/
 
 
 .. _codespell: https://github.com/codespell-project/codespell/
@@ -88,14 +88,14 @@ You can install it and a few other necessary packages with::
 
 To create the HTML pages, use::
 
-    python -m sphinx docs/ build/sphinx/html -b html
+    python -m sphinx docs/ build/html -b html
 
 The generated files will be available
-in the directory :file:`build/sphinx/html/`.
+in the directory :file:`build/html/`.
 
 It is also possible to automatically check if all links are still valid::
 
-    python -m sphinx docs/ build/sphinx/html -b linkcheck
+    python -m sphinx docs/ build/html -b linkcheck
 
 .. _Sphinx: https://www.sphinx-doc.org
 


### PR DESCRIPTION
We need to hard code the sphinx build dir inside `conf.py` at the moment as we need the path to store the example WAV files.
This means the path when building the docs we mention in `CONTRIBUTING.rst` has to match the path we use inside `conf.py` which was not the case before.

In addition, I also fixed to instances that were still mentioning `audfoo` instead of `auglib` in CONTRIBUTING.rst.