### PR TITLE
Depend on audeer>=2.0.0

### DIFF
--- a/auglib/core/cache.py
+++ b/auglib/core/cache.py
@@ -50,4 +50,4 @@ def default_cache_root(augment: Augment = None) -> str:
     root = os.environ.get("AUGLIB_CACHE_ROOT") or config.CACHE_ROOT
     if augment is not None:
         root = os.path.join(root, augment.short_id)
-    return audeer.path(root)
+    return audeer.path(root, follow_symlink=True)

--- a/auglib/core/interface.py
+++ b/auglib/core/interface.py
@@ -16,20 +16,6 @@ from auglib.core import transform
 from auglib.core.seed import seed as seed_func
 
 
-def _remove(path: str):  # pragma: no cover
-    path = audeer.path(path)
-    if os.path.exists(path):
-        os.remove(path)
-
-
-def _make_tree(files: typing.Sequence[str]):  # pragma: no cover
-    dirs = set()
-    for f in files:
-        dirs.add(os.path.dirname(f))
-    for d in list(dirs):
-        audeer.mkdir(d)
-
-
 class Augment(audinterface.Process, audobject.Object):
     r"""Augmentation interface.
 
@@ -113,7 +99,6 @@ class Augment(audinterface.Process, audobject.Object):
 
     Examples:
         >>> import audb
-        >>> import audeer
         >>> import audiofile
         >>> import auglib
         >>> db = audb.load(
@@ -302,7 +287,7 @@ class Augment(audinterface.Process, audobject.Object):
 
             cache_root = default_cache_root()
         else:
-            cache_root = audeer.path(cache_root)
+            cache_root = audeer.path(cache_root, follow_symlink=True)
         cache_root = os.path.join(cache_root, self.short_id)
 
         transform_path = os.path.join(cache_root, "transform.yaml")
@@ -572,7 +557,6 @@ def _augmented_files(
     remove_root: str = None,
 ) -> typing.Sequence[str]:
     r"""Return cache file names by joining with the cache directory."""
-    cache_root = audeer.path(cache_root)
     if remove_root is None:
 
         def join(path1: str, path2: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ classifiers = [
     'Topic :: Scientific/Engineering',
 ]
 dependencies = [
-    'audformat >=0.15.2',
+    'audeer >=2.0.0',
+    'audformat >=1.1.0',
     'audinterface >=1.0.4',
     'audmath >=1.3.0',
     'audobject >=0.7.6',

--- a/tests/test_interface.py
+++ b/tests/test_interface.py
@@ -461,7 +461,7 @@ def test_augment(
 
 
 def test_augment_cache(tmpdir):
-    root = audeer.mkdir(os.path.join(tmpdir, "input"))
+    root = audeer.mkdir(tmpdir, "input")
     cache_root = os.path.join(tmpdir, "cache")
     transform = auglib.transform.PinkNoise()
     augment = auglib.Augment(transform, seed=0)
@@ -601,7 +601,7 @@ def test_augment_cache_nat(
     expected_index_nat,
     expected_index_no_nat,
 ):
-    root = audeer.mkdir(os.path.join(tmpdir, "input"))
+    root = audeer.mkdir(tmpdir, "input")
     cache_root = os.path.join(tmpdir, "cache")
     augment_no_nat = auglib.Augment(
         transform,


### PR DESCRIPTION
Makes sure the cache root of `auglib` is not returned as a symlink when using `audeer>=2.0.0`.

In addition, code was slightly clean up by removing unused private functions.