### PR TITLE
DOC: add badges to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,6 +2,8 @@
 auglib
 ======
 
+|tests| |coverage| |docs| |python-versions| |license|
+
 **auglib** is an augmentation library,
 which provides transforms_
 to modify audio signals_ and files_.
@@ -32,3 +34,21 @@ and listen to examples_.
 .. _transforms: https://audeering.github.io/api/auglib.transform.html
 .. _usage: https://audeering.github.io/usage.html
 .. _user defined: https://audeering.github.io/api/auglib.transform.Function.html
+
+
+.. badges images and links:
+.. |tests| image:: https://github.com/audeering/auglib/workflows/Test/badge.svg
+    :target: https://github.com/audeering/auglib/actions?query=workflow%3ATest
+    :alt: Test status
+.. |coverage| image:: https://codecov.io/gh/audeering/auglib/branch/main/graph/badge.svg?token=3J0sF7GQhA
+    :target: https://codecov.io/gh/audeering/auglib/
+    :alt: code coverage
+.. |docs| image:: https://img.shields.io/pypi/v/auglib?label=docs
+    :target: https://audeering.github.io/auglib/
+    :alt: auglib's documentation
+.. |license| image:: https://img.shields.io/badge/license-MIT-green.svg
+    :target: https://github.com/audeering/auglib/blob/main/LICENSE
+    :alt: auglib's MIT license
+.. |python-versions| image:: https://img.shields.io/pypi/pyversions/auglib.svg
+    :target: https://pypi.org/project/auglib/
+    :alt: auglib's supported Python versions


### PR DESCRIPTION
Add badges for tests, code coverage, license, Python package versions and docs to README.

NOTE: docs and Python packages are empty for now until we have our first public release.

![image](https://github.com/audeering/auglib/assets/173624/b3f4f97c-db4a-41f3-9327-f5f9ea286f5d)

