### PR TITLE
DOC: remove footer links and add github link

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -84,6 +84,10 @@ html_theme = "sphinx_audeering_theme"
 html_theme_options = {
     "display_version": True,
     "logo_only": False,
+    "footer_links": False,
+}
+html_context = {
+    "display_github": True,
 }
 html_title = title
 


### PR DESCRIPTION
This removes the footer links to internal audEERING docs and replaces the link to Gitlab repo with a link to the Github repo.