### PR TITLE
CI: fix missing audio examples on Github pages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -82,13 +82,13 @@ jobs:
 
     - name: Build documentation
       run: |
-        python -m sphinx docs/ docs/_build/ -b html
+        python -m sphinx docs/ build/html -b html
 
     - name: Deploy documentation to Github pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/_build
+        publish_dir: ./build/html
 
     # Github release
     - name: Read CHANGELOG


### PR DESCRIPTION
The audio examples are missing in the published documentation as the build folder was not set to the required path in `publish.yml`.