### PR TITLE
Fix auglib.transform.PinkNoise for odd samples

### DIFF
--- a/auglib/core/transform.py
+++ b/auglib/core/transform.py
@@ -3261,10 +3261,14 @@ class PinkNoise(Base):
         def psd(f):
             return 1 / np.where(f == 0, float("inf"), np.sqrt(f))
 
-        white_noise = np.fft.rfft(np.random.randn(samples + 1))
+        # Add extra sample
+        # to ensure correct length for odd samples
+        length = samples + 1
+
+        white_noise = np.fft.rfft(np.random.randn(length))
 
         # Normalized pink noise shape
-        pink_shape = psd(np.fft.rfftfreq(samples + 1))
+        pink_shape = psd(np.fft.rfftfreq(length))
         pink_shape = pink_shape / np.sqrt(np.mean(pink_shape**2))
 
         white_noise_shaped = white_noise * pink_shape

--- a/auglib/core/transform.py
+++ b/auglib/core/transform.py
@@ -3261,16 +3261,16 @@ class PinkNoise(Base):
         def psd(f):
             return 1 / np.where(f == 0, float("inf"), np.sqrt(f))
 
-        white_noise = np.fft.rfft(np.random.randn(samples))
+        white_noise = np.fft.rfft(np.random.randn(samples + 1))
 
         # Normalized pink noise shape
-        pink_shape = psd(np.fft.rfftfreq(samples))
+        pink_shape = psd(np.fft.rfftfreq(samples + 1))
         pink_shape = pink_shape / np.sqrt(np.mean(pink_shape**2))
 
         white_noise_shaped = white_noise * pink_shape
         pink_noise = np.fft.irfft(white_noise_shaped)
 
-        return np.atleast_2d(pink_noise)
+        return np.atleast_2d(pink_noise[:samples])
 
 
 class Prepend(Base):

--- a/tests/test_transform_pink_noise.py
+++ b/tests/test_transform_pink_noise.py
@@ -79,11 +79,13 @@ def test_pink_noise(duration, sampling_rate, gain_db, snr_db):
 @pytest.mark.parametrize(
     "signal",
     [
-        # Failing signal size,
-        # https://github.com/audeering/auglib/issues/23
+        # Odd,
+        # compare https://github.com/audeering/auglib/issues/23
         np.ones((1, 30045)),
+        # Even
+        np.ones((1, 200)),
     ],
 )
-def test_pink_noise_issue23(signal):
+def test_pink_noise_odd_and_even_samples(signal):
     transform = auglib.transform.PinkNoise()
     transform(signal)

--- a/tests/test_transform_pink_noise.py
+++ b/tests/test_transform_pink_noise.py
@@ -88,4 +88,5 @@ def test_pink_noise(duration, sampling_rate, gain_db, snr_db):
 )
 def test_pink_noise_odd_and_even_samples(signal):
     transform = auglib.transform.PinkNoise()
-    transform(signal)
+    augmented_signal = transform(signal)
+    assert signal.shape == augmented_signal.shape

--- a/tests/test_transform_pink_noise.py
+++ b/tests/test_transform_pink_noise.py
@@ -82,7 +82,7 @@ def test_pink_noise(duration, sampling_rate, gain_db, snr_db):
         # Failing signal size,
         # https://github.com/audeering/auglib/issues/23
         np.ones((1, 30045)),
-    ]
+    ],
 )
 def test_pink_noise_issue23(signal):
     transform = auglib.transform.PinkNoise()

--- a/tests/test_transform_pink_noise.py
+++ b/tests/test_transform_pink_noise.py
@@ -74,3 +74,16 @@ def test_pink_noise(duration, sampling_rate, gain_db, snr_db):
     assert noise.shape == expected_noise.shape
     assert noise.dtype == expected_noise.dtype
     np.testing.assert_almost_equal(noise, expected_noise)
+
+
+@pytest.mark.parametrize(
+    "signal",
+    [
+        # Failing signal size,
+        # https://github.com/audeering/auglib/issues/23
+        np.ones((1, 30045)),
+    ]
+)
+def test_pink_noise_issue23(signal):
+    transform = auglib.transform.PinkNoise()
+    transform(signal)


### PR DESCRIPTION
Closes #23 

There was a bug that went noticed for the `PinkNoise` tests as those included only signals with an even number of samples.