### PR TITLE
DOC: fix documentation links in README

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -69,5 +69,5 @@ jobs:
     - name: Test building documentation
       run: python -m sphinx docs/ docs/_build/ -b html -W
 
-    #- name: Check links in documentation
-    #  run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
+    - name: Check links in documentation
+      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W

--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ Have a look at the installation_ instructions
 and listen to examples_.
 
 
-.. _datasets: https://audeering.github.io/auglib/usage.html#augment-a-database-to-disk
+.. _datasets: https://audeering.github.io/auglib/usage.html#augment-a-dataset-to-disk
 .. _examples: https://audeering.github.io/auglib/examples.html
 .. _external: https://audeering.github.io/auglib/external.html
 .. _files: https://audeering.github.io/auglib/usage.html#augment-files-in-memory

--- a/README.rst
+++ b/README.rst
@@ -25,15 +25,15 @@ Have a look at the installation_ instructions
 and listen to examples_.
 
 
-.. _datasets: https://audeering.github.io/usage.html#augment-a-database-to-disk
-.. _examples: https://audeering.github.io/examples.html
-.. _external: https://audeering.github.io/external.html
-.. _files: https://audeering.github.io/usage.html#augment-files-in-memory
-.. _installation: https://audeering.github.io/install.html
-.. _signals: https://audeering.github.io/usage.html#augment-a-signal
-.. _transforms: https://audeering.github.io/api/auglib.transform.html
-.. _usage: https://audeering.github.io/usage.html
-.. _user defined: https://audeering.github.io/api/auglib.transform.Function.html
+.. _datasets: https://audeering.github.io/auglib/usage.html#augment-a-database-to-disk
+.. _examples: https://audeering.github.io/auglib/examples.html
+.. _external: https://audeering.github.io/auglib/external.html
+.. _files: https://audeering.github.io/auglib/usage.html#augment-files-in-memory
+.. _installation: https://audeering.github.io/auglib/install.html
+.. _signals: https://audeering.github.io/auglib/usage.html#augment-a-signal
+.. _transforms: https://audeering.github.io/auglib/api/auglib.transform.html
+.. _usage: https://audeering.github.io/auglib/usage.html
+.. _user defined: https://audeering.github.io/auglib/api/auglib.transform.Function.html
 
 
 .. badges images and links:


### PR DESCRIPTION
Closes #27 

Ensure all the links shown on the landing page work, by re-enabling the CI test for broken links, and fixing the links in the README accordingly.

![image](https://github.com/audeering/auglib/assets/173624/c1b782a9-cd3c-4a7e-8ca7-52375beb57a8)

