### PR TITLE
CI: update actions to switch to Node.js 20

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,40 +16,40 @@ jobs:
         python-version: [ '3.10' ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache air
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/air/1.4.2
         key: air-1.4.2
 
     - name: Cache cough-speech-sneeze
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/cough-speech-sneeze/2.0.1
         key: cough-speech-sneeze-2.0.1
 
     - name: Cache emodb
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/emodb/1.4.1
         key: emodb-1.4.1
 
     - name: Cache micirp
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/micirp/1.0.0
         key: micirp-1.0.0
 
     - name: Cache musan
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/musan/1.0.0
         key: musan-1.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Set up Python 3.10
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,37 +21,37 @@ jobs:
         fetch-depth: 2
 
     - name: Cache air
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/air/1.4.2
         key: air-1.4.2
 
     - name: Cache cough-speech-sneeze
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/cough-speech-sneeze/2.0.1
         key: cough-speech-sneeze-2.0.1
 
     - name: Cache emodb
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/emodb/1.4.1
         key: emodb-1.4.1
 
     - name: Cache micirp
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/micirp/1.0.0
         key: micirp-1.0.0
 
     - name: Cache musan
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/musan/1.0.0
         key: musan-1.0.0
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.10'
 
@@ -85,7 +85,7 @@ jobs:
         python -m sphinx docs/ build/html -b html
 
     - name: Deploy documentation to Github pages
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./build/html
@@ -107,7 +107,7 @@ jobs:
 
     - name: Create release on Github
       id: create_release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,10 @@ jobs:
             tasks: tests
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Cache emodb
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/audb/emodb/1.4.1
         key: emodb-1.4.1
@@ -79,7 +79,7 @@ jobs:
       run: python -m pytest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: ./coverage.xml


### PR DESCRIPTION
As discussed at https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/, we need to update all Github Actions that are still using Node.js 16.

We fix this here by updating to:

* actions/checkout@v4
* actions/cache@v4
* actions/setup-python@v5
* codecov/codecov-action@v4
* softprops/action-gh-release@v2
* peaceiris/actions-gh-pages@v4