### PR TITLE
CI: install mediainfo as cask with homebrew

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,7 +59,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install audio packages
-      run: brew install ffmpeg mediainfo
+      run: brew install ffmpeg homebrew/cask/mediainfo
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install audio packages


### PR DESCRIPTION
This fixes the following warning for the MacOS test workflow:

![image](https://github.com/audeering/auglib/assets/173624/ccd38efc-f68e-4d9a-a005-88c9c981da86)
