### PR TITLE
CI: update node Actions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: 2
 


### PR DESCRIPTION
This tries to avoid the following warning:

![image](https://github.com/audeering/auglib/assets/173624/1050edc2-1def-4cac-a2d2-09a913992efe)
