### PR TITLE
TST: update ruff and codespell versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.8
+    rev: v0.7.0
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.2.4
+    rev: v2.3.0
     hooks:
       - id: codespell
         additional_dependencies:

--- a/auglib/core/transform.py
+++ b/auglib/core/transform.py
@@ -187,7 +187,7 @@ class Base(audobject.Object):
                 is not support
                 by chosen transform parameters
             ValueError: if ``sampling_rate`` is ``None``,
-                but the transform requires a samling rate
+                but the transform requires a sampling rate
             RuntimeError: if the given sampling rate is incompatible
                 with the transform
 

--- a/auglib/observe/__init__.py
+++ b/auglib/observe/__init__.py
@@ -52,6 +52,7 @@ we can do:
 
 
 """
+
 from auglib.core.observe import Base
 from auglib.core.observe import Bool
 from auglib.core.observe import FloatNorm


### PR DESCRIPTION
Update `ruff` and `codespell` pre-commits to the versions we now use in other packages.

## Summary by Sourcery

Update the versions of `ruff` and `codespell` pre-commit hooks to align with other packages and fix a typo in the error message documentation.

Bug Fixes:
- Correct a typo in the error message documentation in `transform.py`.

Build:
- Update `ruff` pre-commit hook to version v0.7.0.
- Update `codespell` pre-commit hook to version v2.3.0.