### PR TITLE
CI: update ruff and code-spell versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,13 +13,13 @@ default_language_version:
 
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.0
+    rev: v0.13.3
     hooks:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         additional_dependencies:

--- a/auglib/core/interface.py
+++ b/auglib/core/interface.py
@@ -347,7 +347,7 @@ class Augment(audinterface.Process, audobject.Object):
                     non_nat_index,
                     cache_root_idx,
                     remove_root,
-                    f"Augment ({idx+1} of {num_variants})",
+                    f"Augment ({idx + 1} of {num_variants})",
                 )
                 pd.to_pickle(
                     augmented_index,
@@ -574,9 +574,7 @@ def _augmented_files(
         dirs = [os.path.dirname(file) for file in unique_files]
         common_root = audeer.common_directory(dirs)
         if not audeer.common_directory([remove_root, common_root]) == remove_root:
-            raise RuntimeError(
-                f"Cannot remove '{remove_root}' " f"from '{common_root}'."
-            )
+            raise RuntimeError(f"Cannot remove '{remove_root}' from '{common_root}'.")
         augmented_files = [
             file.replace(remove_root, cache_root, 1) for file in augmented_files
         ]

--- a/auglib/core/time.py
+++ b/auglib/core/time.py
@@ -103,8 +103,7 @@ class Time(audobject.Object):
         elif self.unit == "relative":
             if length is None:
                 raise ValueError(
-                    "Unit is set to 'relative', "
-                    "but no value is provided for 'length'."
+                    "Unit is set to 'relative', but no value is provided for 'length'."
                 )
             num_samples = int(length * value)
         else:

--- a/auglib/core/transform.py
+++ b/auglib/core/transform.py
@@ -638,7 +638,9 @@ class BabbleNoise(Base):
             >>> import auglib
             >>> import numpy as np
             >>> auglib.seed(1)
-            >>> db = audb.load("musan", media=r".*speech-librivox-000\d", version="1.0.0")
+            >>> db = audb.load(
+            ...     "musan", media=r".*speech-librivox-000\d", version="1.0.0"
+            ... )
             >>> transform = auglib.transform.BabbleNoise(db.files[:5])
             >>> signal = np.zeros((1, 30372))
             >>> augmented_signal = transform(signal)
@@ -1721,7 +1723,7 @@ class Fade(Base):
         for level in [in_db, out_db]:
             if level >= 0:
                 raise ValueError(
-                    "Fading level needs to be below 0 dB, " f"not {level} dB."
+                    f"Fading level needs to be below 0 dB, not {level} dB."
                 )
         self.in_dur = in_dur
         self.out_dur = out_dur
@@ -2004,7 +2006,9 @@ class Function(Base):
             :context: close-figs
             :include-source: True
 
-            >>> transform = auglib.transform.Function(shutter, {"block": 400, "non_block": 800})
+            >>> transform = auglib.transform.Function(
+            ...     shutter, {"block": 400, "non_block": 800}
+            ... )
             >>> augmented_signal = transform(signal)
             >>> audplot.waveform(augmented_signal)
 
@@ -2819,7 +2823,9 @@ class Mix(Base):
             >>> import audplot
             >>> import auglib
             >>> auglib.seed(0)
-            >>> db = audb.load("musan", media=r".*noise-free-sound-000\d", version="1.0.0")
+            >>> db = audb.load(
+            ...     "musan", media=r".*noise-free-sound-000\d", version="1.0.0"
+            ... )
             >>> transform = auglib.transform.Mix(
             ...     auglib.observe.List(db.files, draw=True),
             ...     loop_aux=True,
@@ -3170,7 +3176,9 @@ class PinkNoise(Base):
             >>> import audmath
             >>> import matplotlib.pyplot as plt
             >>> import seaborn as sns
-            >>> magnitude, f = plt.mlab.magnitude_spectrum(augmented_signal[0, :], Fs=16000)
+            >>> magnitude, f = plt.mlab.magnitude_spectrum(
+            ...     augmented_signal[0, :], Fs=16000
+            ... )
             >>> # Smooth magnitude
             >>> magnitude = np.convolve(magnitude, np.ones(14) / 14, mode="same")
             >>> plt.semilogx(f, audmath.db(magnitude), color="#e13b41")
@@ -4498,7 +4506,9 @@ class WhiteNoiseGaussian(Base):
             >>> import audmath
             >>> import matplotlib.pyplot as plt
             >>> import seaborn as sns
-            >>> magnitude, f = plt.mlab.magnitude_spectrum(augmented_signal[0, :], Fs=16000)
+            >>> magnitude, f = plt.mlab.magnitude_spectrum(
+            ...     augmented_signal[0, :], Fs=16000
+            ... )
             >>> # Smooth magnitude
             >>> magnitude = np.convolve(magnitude, np.ones(14) / 14, mode="same")
             >>> plt.semilogx(f, audmath.db(magnitude), color="#e13b41")
@@ -4645,7 +4655,9 @@ class WhiteNoiseUniform(Base):
             >>> import audmath
             >>> import matplotlib.pyplot as plt
             >>> import seaborn as sns
-            >>> magnitude, f = plt.mlab.magnitude_spectrum(augmented_signal[0, :], Fs=16000)
+            >>> magnitude, f = plt.mlab.magnitude_spectrum(
+            ...     augmented_signal[0, :], Fs=16000
+            ... )
             >>> # Smooth magnitude
             >>> magnitude = np.convolve(magnitude, np.ones(14) / 14, mode="same")
             >>> plt.semilogx(f, audmath.db(magnitude), color="#e13b41")

--- a/tests/test_transform_append.py
+++ b/tests/test_transform_append.py
@@ -75,10 +75,7 @@ def test_append(
             np.zeros((1, 2000)),
             False,
             ValueError,
-            (
-                "Unit is set to 'seconds', "
-                "but no value is provided for 'sampling_rate'."
-            ),
+            ("Unit is set to 'seconds', but no value is provided for 'sampling_rate'."),
         ),
         (
             np.ones((1, 4)),

--- a/tests/test_transform_bandpass.py
+++ b/tests/test_transform_bandpass.py
@@ -57,10 +57,7 @@ def test_bandpass(duration, sampling_rate):
             "non-supported",
             16000,
             ValueError,
-            (
-                "Unknown filter design 'non-supported'. "
-                "Supported designs are: butter."
-            ),
+            ("Unknown filter design 'non-supported'. Supported designs are: butter."),
         ),
         (
             "butter",

--- a/tests/test_transform_bandstop.py
+++ b/tests/test_transform_bandstop.py
@@ -57,10 +57,7 @@ def test_bandstop(duration, sampling_rate):
             "non-supported",
             16000,
             ValueError,
-            (
-                "Unknown filter design 'non-supported'. "
-                "Supported designs are: butter."
-            ),
+            ("Unknown filter design 'non-supported'. Supported designs are: butter."),
         ),
         (
             "butter",

--- a/tests/test_transform_highpass.py
+++ b/tests/test_transform_highpass.py
@@ -52,10 +52,7 @@ def test_highpass(sampling_rate, duration, order, cutoff):
             "non-supported",
             16000,
             ValueError,
-            (
-                "Unknown filter design 'non-supported'. "
-                "Supported designs are: butter."
-            ),
+            ("Unknown filter design 'non-supported'. Supported designs are: butter."),
         ),
         (
             "butter",

--- a/tests/test_transform_lowpass.py
+++ b/tests/test_transform_lowpass.py
@@ -52,10 +52,7 @@ def test_lowpass(duration, sampling_rate, order, cutoff):
             "non-supported",
             16000,
             ValueError,
-            (
-                "Unknown filter design 'non-supported'. "
-                "Supported designs are: butter."
-            ),
+            ("Unknown filter design 'non-supported'. Supported designs are: butter."),
         ),
         (
             "butter",

--- a/tests/test_transform_resample.py
+++ b/tests/test_transform_resample.py
@@ -65,7 +65,7 @@ def test_resample_errors(
 
 def test_resample_warning():
     expected_warning = (
-        "'override' argument is ignored " "and will be removed with version 1.2.0."
+        "'override' argument is ignored and will be removed with version 1.2.0."
     )
     with pytest.warns(UserWarning, match=expected_warning):
         auglib.transform.Resample(8000, override=True)

--- a/tests/test_transform_trim.py
+++ b/tests/test_transform_trim.py
@@ -442,11 +442,7 @@ def test_Trim_error_call(
             "none",
             "unknown",
             ValueError,
-            (
-                "Unknown fill_pos 'unknown'. "
-                "Supported positions are: "
-                "right, left, both."
-            ),
+            ("Unknown fill_pos 'unknown'. Supported positions are: right, left, both."),
         ),
     ],
 )


### PR DESCRIPTION
Update `ruff` and `codespell` used for linting.

## Summary by Sourcery

Update linting tooling versions and adjust code and tests to satisfy new formatting rules.

Enhancements:
- Reformat docstring examples and error messages for consistency with updated linting and style rules.

CI:
- Bump ruff and codespell pre-commit hook versions in the configuration file.