### PR TITLE
Fix license syntax in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ authors = [
 ]
 description = 'Audio augmentations'
 readme = 'README.rst'
-license = {file = 'LICENSE'}
+license = 'MIT'
+license-files = ['LICENSE']
 keywords = [
     'audio',
     'data',
@@ -24,7 +25,6 @@ classifiers = [
     'Development Status :: 5 - Production/Stable',
     'Intended Audience :: Science/Research',
     'Intended Audience :: Developers',
-    'License :: OSI Approved :: MIT License',
     'Operating System :: OS Independent',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',


### PR DESCRIPTION
Update `pyproject.toml` to the new required syntax for specifying a license.