### PR TITLE
Include only auglib* in Python package

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -61,9 +61,10 @@ jobs:
       uses: astral-sh/setup-uv@v5
 
     - name: Ubuntu - install libsndfile
-      run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg sox libavcodec-extra
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+      with:
+        packages: libsndfile1 ffmpeg sox libavcodec-extra
+        version: 1.0
 
     - name: Test building documentation
       run: uv run python -m sphinx docs/ docs/_build/ -b html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,8 +73,10 @@ jobs:
 
     # Documentation
     - name: Install doc dependencies
-      run: |
-        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg sox libavcodec-extra
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+      with:
+        packages: libsndfile1 ffmpeg sox libavcodec-extra
+        version: 1.0
 
     - name: Build documentation
       run: uv run python -m sphinx docs/ build/html -b html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,9 +56,10 @@ jobs:
       run: micromamba install sox
 
     - name: Ubuntu - install audio packages
-      run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1 ffmpeg libavcodec-extra
+      uses: awalsh128/cache-apt-pkgs-action@acb598e5ddbc6f68a970c5da0688d2f3a9f04d05  # v1.6.0
+      with:
+        packages: libsndfile1 ffmpeg libavcodec-extra
+        version: 1.0
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install audio packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,11 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install audio packages
-      run: brew install ffmpeg mediainfo
+      run: |
+        brew uninstall --ignore-dependencies ffmpeg || true
+        brew tap homebrew-ffmpeg/ffmpeg
+        brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-opencore-amr
+        brew install mediainfo
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install audio packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,11 +62,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install audio packages
-      run: |
-        brew uninstall --ignore-dependencies ffmpeg || true
-        brew tap homebrew-ffmpeg/ffmpeg
-        brew install homebrew-ffmpeg/ffmpeg/ffmpeg --with-opencore-amr
-        brew install mediainfo
+      run: micromamba install --yes -c conda-forge ffmpeg mediainfo
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install audio packages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,7 +62,12 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
 
     - name: OSX - install audio packages
-      run: micromamba install --yes -c conda-forge ffmpeg mediainfo
+      run: |
+        curl -L -o ffmpeg.zip https://evermeet.cx/ffmpeg/getrelease/ffmpeg/zip
+        unzip -o ffmpeg.zip
+        sudo mv -f ffmpeg /usr/local/bin/ffmpeg
+        sudo chmod +x /usr/local/bin/ffmpeg
+        brew install mediainfo
       if: matrix.os == 'macOS-latest'
 
     - name: Windows - install audio packages

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -234,11 +234,7 @@ convention = 'google'
 #
 # Find all (sub-)modules of the Python package
 [tool.setuptools.packages.find]
-exclude = [
-    'tests*',
-    'docs*',
-    'misc*',
-]
+include = ['auglib*']
 
 [tool.setuptools.package-data]
 auglib = ['core/bin/*']


### PR DESCRIPTION
This restricts the files included in the Python package to `auglib*`.

Same fix as audeering/audb#560 (audeering/audb#559). The previous `exclude = ['tests*', 'docs*', 'misc*']` blacklist worked but is fragile — any new top-level directory (e.g. `examples/`, `notebooks/`, `benchmarks/`) would silently be packaged and end up under `site-packages/`, shadowing local packages of the same name in downstream projects. Switching to a `include` whitelist makes the intent explicit and future-proof.