### PR TITLE
CI: update checkout, setup-python, setup-uv, codecov

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -16,49 +16,49 @@ jobs:
         python-version: [ '3.12' ]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         # Ensure a dynamic version is assigned
         fetch-tags: true
         fetch-depth: 20
 
     - name: Cache air
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/air/1.4.2
         key: air-1.4.2
 
     - name: Cache cough-speech-sneeze
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/cough-speech-sneeze/2.0.1
         key: cough-speech-sneeze-2.0.1
 
     - name: Cache emodb
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/emodb/1.4.1
         key: emodb-1.4.1
 
     - name: Cache micirp
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/micirp/1.0.0
         key: micirp-1.0.0
 
     - name: Cache musan
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/musan/1.0.0
         key: musan-1.0.0
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Ubuntu - install libsndfile
       run: |

--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -59,6 +59,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Ubuntu - install libsndfile
       run: |

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,15 +12,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Python 3.12
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     - name: Install pre-commit hooks
       run: uvx pre-commit install --install-hooks

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,47 +16,47 @@ jobs:
       group: ${{ github.workflow }}-${{ github.ref }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
       with:
         fetch-depth: 2
 
     - name: Cache air
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/air/1.4.2
         key: air-1.4.2
 
     - name: Cache cough-speech-sneeze
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/cough-speech-sneeze/2.0.1
         key: cough-speech-sneeze-2.0.1
 
     - name: Cache emodb
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/emodb/1.4.1
         key: emodb-1.4.1
 
     - name: Cache micirp
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/micirp/1.0.0
         key: micirp-1.0.0
 
     - name: Cache musan
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/musan/1.0.0
         key: musan-1.0.0
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v7
       with:
         python-version: '3.12'
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v5
+      uses: astral-sh/setup-uv@v9.0.0
 
     # PyPI package
     - name: Build Python package

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v9.0.0
+      with:
+        cache-suffix: ${{ github.workflow }}
 
     # PyPI package
     - name: Build Python package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,7 @@ jobs:
         key: emodb-1.4.1
 
     - name: Set up Python ${{ matrix.python-version }} with Micromamba
-      uses: mamba-org/setup-micromamba@v2
+      uses: mamba-org/setup-micromamba@v3
       with:
         cache-environment: true
         environment-name: .venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,10 +35,10 @@ jobs:
             tasks: tests
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Cache emodb
-      uses: actions/cache@v4
+      uses: actions/cache@v6
       with:
         path: ~/audb/emodb/1.4.1
         key: emodb-1.4.1
@@ -85,8 +85,8 @@ jobs:
       run: uv run --active pytest
 
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
-        file: ./coverage.xml
+        files: ./coverage.xml
       if: matrix.os == 'ubuntu-24.04'


### PR DESCRIPTION
## Summary

Two related CI bugs, both caused by stale GitHub Action version pins:

1. **Dead uv caching**: `astral-sh/setup-uv`'s default `cache-dependency-glob`
   keys on `uv.lock`/`requirements*.txt`, neither of which exists here (no
   committed lockfile, by design), so caching never actually worked. Bumped
   `astral-sh/setup-uv` `v5` -> `v9.0.0` in publish.yml (the only workflow
   that calls it directly; test.yml installs uv via
   `mamba-org/setup-micromamba`, left untouched).

2. **Node.js 20 deprecation**: `actions/checkout` and `actions/setup-python`
   bumped `v4`/`v5` -> `v7`, clearing the "Node.js 20 is deprecated" warning.
   `codecov/codecov-action` bumped `v4` -> `v7`; its `v5` rewrite dropped the
   singular `file:` input in favor of `files:`, renamed accordingly.
   `actions/cache` (used for the air/cough-speech-sneeze/emodb/micirp/musan
   test-data caches across doc/publish/test workflows) bumped `v4` -> `v6`
   for the same reason.

`prune-cache` left at its new default (off): auglib's runtime dependency
tree (audeer, audformat, audinterface, audmath, audobject, scipy) has no
large pre-built binary wheels like torch, so pruning would save ~0 disk
space while costing avoidable re-downloads.

Part of the same CI cleanup as audeering/audeer#206,
audeering/opensmile-python#132, audeering/audb#591,
audeering/audformat#539, audeering/audbackend#307, and
audeering/audresample#83.

## Test plan

- [x] All workflow YAML files reviewed and diff-verified against the
      established pattern from sibling repos
- [ ] CI passes on this PR